### PR TITLE
remove unneeded argument

### DIFF
--- a/pymatgen/analysis/defects/pawpyseed_analysis.py
+++ b/pymatgen/analysis/defects/pawpyseed_analysis.py
@@ -26,7 +26,7 @@ def get_level_projection_amounts(defect_path, bulk_path, spinpol = False, bands_
         bulk_basis = bulk_path
     defect = Wavefunction.from_atomate_directory(defect_path, False)
 
-    projector = Projector(wf = defect, basis = bulk_basis, projector_list = None,
+    projector = Projector(wf = defect, basis = bulk_basis,
                          unsym_basis = unsym and mb, unsym_wf = unsym, pseudo = False)
     if bands_to_project == None:
         bands_to_project = np.arange(defect.nband)


### PR DESCRIPTION
Missed a minor error because I was testing a couple commits behind on pawpyseed. I did the test on the most recent commit of pawpyseed and fixed the issue.